### PR TITLE
Fixed a connection leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Installation
 
 ```
-yarn add git+https://github.com/gpsgate/react-native-eventsource.git
+yarn add git+https://github.com/ExpandoPakistan/react-native-eventsource.git
 ```
 
 ### Usage


### PR DESCRIPTION
The processAbort() method used when calling close() on event source was leaking the http connection. As a result we were having loads of zombie inactive connections on the server.
The fix:
![image](https://user-images.githubusercontent.com/16245985/101443968-5152c080-3940-11eb-89d9-bf474b7d2370.png)
